### PR TITLE
Add feature merging utility for forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ This command trains the model and saves the weights to `model.pt`.
 
 ## Forecasting
 
-The `forecast.py` script loads the trained model and a features CSV (for example the first round of 2025) and prints an initial forecast with uncertainty estimates:
+The `forecast.py` script can combine multiple first round result files and optionally demographics before running the forecast. Pass `--features` for each results CSV and `--demo` for the demographics table:
 
 ```bash
-python forecast.py --features data/pv_part_cntry_prsd_05062025.csv --model model.pt
+python forecast.py \
+  --features data/pv_part_cntry_prsd_05062025.csv \
+  --features data/pv_part_cntry_prsd_c_05062025.csv \
+  --demo data/demographics_05042025.csv \
+  --model model.pt
 ```
+
+Behind the scenes these files are merged on the precinct ID columns via `load_features` in `runoff_model.py`. The script then prints an initial forecast with uncertainty estimates.
 
 Real-time updates can be performed by using the `ElectionForecaster` class from `runoff_model.py` and calling `update_precinct` as results come in.

--- a/forecast.py
+++ b/forecast.py
@@ -1,20 +1,32 @@
 import argparse
 from pathlib import Path
 
-import pandas as pd
 import torch
 
-from runoff_model import RunoffPredictor, dataframe_to_tensor, ElectionForecaster
+from runoff_model import (
+    RunoffPredictor,
+    dataframe_to_tensor,
+    ElectionForecaster,
+    load_features,
+)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run live forecast")
-    parser.add_argument("--features", required=True, help="CSV with 2025 first round features")
+    parser.add_argument(
+        "--features",
+        action="append",
+        required=True,
+        help="Path to first round results CSV. May be passed multiple times.",
+    )
+    parser.add_argument("--demo", help="Optional demographics CSV")
     parser.add_argument("--model", default="model.pt", help="Trained model weights")
     parser.add_argument("--id-cols", nargs="*", default=["Judet", "UAT", "Siruta", "Nr sectie"], help="Columns identifying a precinct")
     args = parser.parse_args()
 
-    features = pd.read_csv(args.features)
+    feature_paths = [Path(p) for p in args.features]
+    demo_path = Path(args.demo) if args.demo else None
+    features = load_features(feature_paths, demo_path, args.id_cols)
     X = dataframe_to_tensor(features.drop(columns=args.id_cols))
     model = RunoffPredictor(X.shape[1])
     state = torch.load(args.model, map_location=torch.device("cpu"))


### PR DESCRIPTION
## Summary
- implement `load_features` to merge first round result files and optional demographics
- allow multiple `--features` flags and new `--demo` option in `forecast.py`
- document new workflow in README

## Testing
- `python -m py_compile forecast.py runoff_model.py train.py`