### PR TITLE
Support training on multiple elections

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ python train.py \
   --dan-col DANCILA_VIORICA
 ```
 
+To train on multiple past elections at once, simply pass several paths to each
+option:
+
+```bash
+python train.py \
+  --demo data/demographics_11102019.csv data/demographics_11242024.csv \
+  --first data/pv_part_cntry_prsd_11102019.csv data/pv_part_cntry_prsd_11242024.csv \
+  --second data/pv_part_cntry_prsd_11242019.csv data/pv_part_cntry_prsd_11242024.csv \
+  --simion-col IOHANNIS_KLAUS_WERNER \
+  --dan-col DANCILA_VIORICA
+```
+
 This command trains the model and saves the weights to `model.pt`.
 
 ## Forecasting

--- a/runoff_model.py
+++ b/runoff_model.py
@@ -77,6 +77,26 @@ def prepare_training_data(
     return ElectionData(features=features, target_simion=target_simion, target_dan=target_dan)
 
 
+def load_multi_election_data(
+    demo_paths: List[Path],
+    first_round_paths: List[Path],
+    second_round_paths: List[Path],
+    id_cols: List[str],
+    simion_col: str,
+    dan_col: str,
+) -> ElectionData:
+    """Load and concatenate training data from several elections."""
+    datasets = []
+    for d_path, f_path, s_path in zip(demo_paths, first_round_paths, second_round_paths):
+        datasets.append(
+            prepare_training_data(d_path, f_path, s_path, id_cols, simion_col, dan_col)
+        )
+    features = pd.concat([d.features for d in datasets], ignore_index=True)
+    target_simion = pd.concat([d.target_simion for d in datasets], ignore_index=True)
+    target_dan = pd.concat([d.target_dan for d in datasets], ignore_index=True)
+    return ElectionData(features=features, target_simion=target_simion, target_dan=target_dan)
+
+
 def dataframe_to_tensor(df: pd.DataFrame) -> torch.Tensor:
     """Convert numeric dataframe to a float32 tensor."""
     numeric = df.select_dtypes(include=[np.number]).fillna(0)

--- a/train.py
+++ b/train.py
@@ -3,22 +3,30 @@ from pathlib import Path
 
 import torch
 
-from runoff_model import prepare_training_data, train_model
+from runoff_model import load_multi_election_data, train_model
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train runoff prediction model")
-    parser.add_argument("--demo", required=True, help="Path to demographics CSV")
-    parser.add_argument("--first", required=True, help="Path to first round results CSV")
-    parser.add_argument("--second", required=True, help="Path to second round results CSV")
+    parser.add_argument("--demo", required=True, nargs="+", help="Paths to demographics CSVs")
+    parser.add_argument("--first", required=True, nargs="+", help="Paths to first round results CSVs")
+    parser.add_argument("--second", required=True, nargs="+", help="Paths to second round results CSVs")
     parser.add_argument("--simion-col", required=True, help="Column name of Simion votes in second round")
     parser.add_argument("--dan-col", required=True, help="Column name of Dan votes in second round")
     parser.add_argument("--output", default="model.pt", help="Where to save trained model")
     args = parser.parse_args()
 
     id_cols = ["Judet", "UAT", "Siruta", "Nr sectie"]
-    data = prepare_training_data(
-        Path(args.demo), Path(args.first), Path(args.second), id_cols, args.simion_col, args.dan_col
+    demo_paths = [Path(p) for p in args.demo]
+    first_paths = [Path(p) for p in args.first]
+    second_paths = [Path(p) for p in args.second]
+    data = load_multi_election_data(
+        demo_paths,
+        first_paths,
+        second_paths,
+        id_cols,
+        args.simion_col,
+        args.dan_col,
     )
     model = train_model(data)
     torch.save(model.state_dict(), args.output)


### PR DESCRIPTION
## Summary
- enable passing lists of data files to `train.py`
- add `load_multi_election_data` helper
- document multiple-election usage in `README`

## Testing
- `python -m py_compile train.py runoff_model.py forecast.py`